### PR TITLE
Bump version to 0.2.1 and add support for new OpenAI model

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cloving",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "packageManager": "yarn@1.22.22",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/cloving_gpt/adapters/openai.ts
+++ b/src/cloving_gpt/adapters/openai.ts
@@ -5,6 +5,7 @@ export class OpenAIAdapter implements Adapter {
   private model: string
 
   static supportedModels: string[] = [
+    'openai:gpt:4o-2024-08-06',
     'openai:gpt:4o',
     'openai:gpt:4o-mini',
     'openai:gpt:4-turbo',


### PR DESCRIPTION
- Update package version from 0.2.0 to 0.2.1
- Add 'openai:gpt:4o-2024-08-06' to supported models in OpenAIAdapter