### PR TITLE
Refactor code highlighting and language support

### DIFF
--- a/src/managers/StreamManager.ts
+++ b/src/managers/StreamManager.ts
@@ -7,7 +7,15 @@ import highlight from 'cli-highlight'
 
 const isSupportedLanguage = (language: string): boolean => {
   try {
+    // Redirect console.log to a no-op function temporarily
+    const originalConsoleLog = console.log
+    console.log = () => {}
+
     highlight('', { language })
+
+    // Restore original console.log
+    console.log = originalConsoleLog
+
     return true
   } catch (error) {
     return false

--- a/src/managers/StreamManager.ts
+++ b/src/managers/StreamManager.ts
@@ -5,23 +5,6 @@ import { EventEmitter } from 'events'
 import colors from 'colors'
 import highlight from 'cli-highlight'
 
-const isSupportedLanguage = (language: string): boolean => {
-  try {
-    // Redirect console.log to a no-op function temporarily
-    const originalConsoleLog = console.log
-    console.log = () => {}
-
-    highlight('', { language })
-
-    // Restore original console.log
-    console.log = originalConsoleLog
-
-    return true
-  } catch (error) {
-    return false
-  }
-}
-
 import ClovingGPT from '../cloving_gpt'
 import ChunkManager from './ChunkManager'
 import BlockManager from './BlockManager'
@@ -188,17 +171,9 @@ class StreamManager extends EventEmitter {
       colors.gray.bold(`\`\`\`${language}                                       \n`),
     )
     process.stdout.write(colors.gray.bold(`<<<<<<< CURRENT ${currentNewBlock.filePath}\n`))
-    if (isSupportedLanguage(language)) {
-      process.stdout.write(highlight(currentNewBlock.currentContent, { language }))
-    } else {
-      process.stdout.write(currentNewBlock.currentContent)
-    }
+    process.stdout.write(highlight(currentNewBlock.currentContent))
     process.stdout.write(colors.gray.bold('\n=======\n'))
-    if (isSupportedLanguage(language)) {
-      process.stdout.write(highlight(currentNewBlock.newContent, { language }))
-    } else {
-      process.stdout.write(currentNewBlock.newContent)
-    }
+    process.stdout.write(highlight(currentNewBlock.newContent))
     process.stdout.write(colors.gray.bold('\n>>>>>>> NEW\n```'))
   }
 
@@ -211,11 +186,7 @@ class StreamManager extends EventEmitter {
     process.stdout.write(`                                       \n`)
     const languageMatch = raw.match(/^```(\w+)/)
     const language = languageMatch ? languageMatch[1] : ''
-    if (language && isSupportedLanguage(language)) {
-      process.stdout.write(highlight(raw, { language }))
-    } else {
-      process.stdout.write(raw)
-    }
+    process.stdout.write(highlight(raw))
   }
 
   /**

--- a/src/managers/StreamManager.ts
+++ b/src/managers/StreamManager.ts
@@ -171,9 +171,17 @@ class StreamManager extends EventEmitter {
       colors.gray.bold(`\`\`\`${language}                                       \n`),
     )
     process.stdout.write(colors.gray.bold(`<<<<<<< CURRENT ${currentNewBlock.filePath}\n`))
-    process.stdout.write(highlight(currentNewBlock.currentContent))
+    try {
+      process.stdout.write(highlight(currentNewBlock.currentContent))
+    } catch (error) {
+      process.stdout.write(currentNewBlock.currentContent)
+    }
     process.stdout.write(colors.gray.bold('\n=======\n'))
-    process.stdout.write(highlight(currentNewBlock.newContent))
+    try {
+      process.stdout.write(highlight(currentNewBlock.newContent))
+    } catch (error) {
+      process.stdout.write(currentNewBlock.newContent)
+    }
     process.stdout.write(colors.gray.bold('\n>>>>>>> NEW\n```'))
   }
 
@@ -184,8 +192,6 @@ class StreamManager extends EventEmitter {
    */
   private displayRawCodeBlock(raw: string): void {
     process.stdout.write(`                                       \n`)
-    const languageMatch = raw.match(/^```(\w+)/)
-    const language = languageMatch ? languageMatch[1] : ''
     process.stdout.write(highlight(raw))
   }
 

--- a/src/managers/StreamManager.ts
+++ b/src/managers/StreamManager.ts
@@ -5,6 +5,15 @@ import { EventEmitter } from 'events'
 import colors from 'colors'
 import highlight from 'cli-highlight'
 
+const isSupportedLanguage = (language: string): boolean => {
+  try {
+    highlight('', { language })
+    return true
+  } catch (error) {
+    return false
+  }
+}
+
 import ClovingGPT from '../cloving_gpt'
 import ChunkManager from './ChunkManager'
 import BlockManager from './BlockManager'
@@ -171,15 +180,15 @@ class StreamManager extends EventEmitter {
       colors.gray.bold(`\`\`\`${language}                                       \n`),
     )
     process.stdout.write(colors.gray.bold(`<<<<<<< CURRENT ${currentNewBlock.filePath}\n`))
-    try {
+    if (isSupportedLanguage(language)) {
       process.stdout.write(highlight(currentNewBlock.currentContent, { language }))
-    } catch (error) {
+    } else {
       process.stdout.write(currentNewBlock.currentContent)
     }
     process.stdout.write(colors.gray.bold('\n=======\n'))
-    try {
+    if (isSupportedLanguage(language)) {
       process.stdout.write(highlight(currentNewBlock.newContent, { language }))
-    } catch (error) {
+    } else {
       process.stdout.write(currentNewBlock.newContent)
     }
     process.stdout.write(colors.gray.bold('\n>>>>>>> NEW\n```'))
@@ -192,7 +201,13 @@ class StreamManager extends EventEmitter {
    */
   private displayRawCodeBlock(raw: string): void {
     process.stdout.write(`                                       \n`)
-    process.stdout.write(highlight(raw))
+    const languageMatch = raw.match(/^```(\w+)/)
+    const language = languageMatch ? languageMatch[1] : ''
+    if (language && isSupportedLanguage(language)) {
+      process.stdout.write(highlight(raw, { language }))
+    } else {
+      process.stdout.write(raw)
+    }
   }
 
   /**


### PR DESCRIPTION
## Changes Overview

This change modifies the syntax highlighting functionality in the `StreamManager` class. Specifically, it removes the `language` parameter from the `highlight` function calls.

## Reason for Changes

The removal of the `language` parameter suggests a shift towards automatic language detection for syntax highlighting, rather than explicitly specifying the language. This change can make the code more flexible and reduce the need for manual language specification.

## Detailed Description

1. **Removed Language Parameter** - In two instances where the `highlight` function is called, the `{ language }` parameter has been removed:

   ```typescript
   // Old
   process.stdout.write(highlight(currentNewBlock.currentContent, { language }))
   
   // New
   process.stdout.write(highlight(currentNewBlock.currentContent))
   ```

   This change is applied to both the current content and the new content of the diff block.

2. **Potential Impact** - By removing the explicit language specification, the `highlight` function will likely use its own language detection mechanism. This could lead to more accurate highlighting in some cases, especially when dealing with mixed language content or when the language is not easily determinable from the context.