### PR TITLE
Refine instructions for CURRENT/NEW blocks in ChatManager

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cloving",
-  "version": "0.3.14",
+  "version": "0.3.15",
   "packageManager": "yarn@1.22.22",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/managers/ChatManager.ts
+++ b/src/managers/ChatManager.ts
@@ -708,8 +708,8 @@ ${prompt}
 
 ### Note
 
-Whenever possible, break up the changes into pieces and make sure every change is in its own CURRENT / NEW block.
-Do not allow empty CURRENT blocks and if you add content to the CURRENT block, you also have to add the same content to the NEW block.`
+Whenever possible, break up the changes into pieces and make sure every change is in its own *CURRENT/NEW* Blocks.
+Do not allow empty CURRENT blocks in *CURRENT/NEW* Blocks and if you add content to the CURRENT block, you also have to add the same content to the NEW block.`
   }
 
   private handleClose() {


### PR DESCRIPTION
## Changes Overview

This code review covers two small but significant changes:

1. An update to the package version in `package.json`.
2. Modifications to the formatting of instructions in the `ChatManager.ts` file.

## Reason for Changes

These changes appear to be part of ongoing maintenance and improvement of the codebase:

1. The version update likely reflects new features or bug fixes being released.
2. The prompt formatting changes aim to improve clarity and consistency in the instructions given to the AI model.

## Detailed Description

### 1. Package Version Update

In `package.json`:

```diff
-  "version": "0.3.14",
+  "version": "0.3.15",
```

This minor version bump (from 0.3.14 to 0.3.15) indicates that new features or improvements have been added that are backwards compatible.

### 2. Prompt Formatting in ChatManager.ts

In the `ChatManager.ts` file:

```diff
-Whenever possible, break up the changes into pieces and make sure every change is in its own CURRENT / NEW block.
-Do not allow empty CURRENT blocks and if you add content to the CURRENT block, you also have to add the same content to the NEW block.`
+Whenever possible, break up the changes into pieces and make sure every change is in its own *CURRENT/NEW* Blocks.
+Do not allow empty CURRENT blocks in *CURRENT/NEW* Blocks and if you add content to the CURRENT block, you also have to add the same content to the NEW block.`
```

These changes:
- Use asterisks to emphasize `*CURRENT/NEW*`
- Consistently refer to "Blocks" (capitalized)
- Clarify that empty CURRENT blocks are not allowed specifically in *CURRENT/NEW* Blocks