### PR TITLE
Add new OpenAI o1-preview and o1-mini models

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cloving",
-  "version": "0.3.15",
+  "version": "0.3.16",
   "packageManager": "yarn@1.22.22",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/cloving_gpt/adapters/openai.ts
+++ b/src/cloving_gpt/adapters/openai.ts
@@ -7,6 +7,8 @@ export class OpenAIAdapter implements Adapter {
 
   // List of supported models
   static supportedModels: string[] = [
+    'openai:gpt:o1-preview',
+    'openai:gpt:o1-mini',
     'openai:gpt:4o-2024-08-06',
     'openai:gpt:4o',
     'openai:gpt:4o-mini',


### PR DESCRIPTION
## Changes Overview

This update includes two main changes:

1. Addition of new OpenAI models to the supported models list
2. Version bump in the package.json file

## Reason for Changes

These changes are being made to:

1. Expand the range of available OpenAI models for users of the cloving package
2. Reflect the addition of new features or changes in the package version

## Detailed Description

### 1. New OpenAI Models

Two new models have been added to the `supportedModels` array in the `OpenAIAdapter` class:

```typescript
'openai:gpt:o1-preview',
'openai:gpt:o1-mini',
```

These additions expand the range of OpenAI models that can be used with the cloving package. The 'o1' prefix suggests these might be new or experimental models from OpenAI.

### 2. Version Bump

The version number in `package.json` has been incremented:

```json
-  "version": "0.3.15",
+  "version": "0.3.16",
```

This minor version bump (0.3.15 to 0.3.16) indicates that new features have been added in a backwards-compatible manner, following semantic versioning principles.