### PR TITLE
Refactor config retrieval to use nearest Cloving config

### DIFF
--- a/src/commands/generate/context.ts
+++ b/src/commands/generate/context.ts
@@ -5,7 +5,7 @@ import path from 'path'
 import { input, confirm } from '@inquirer/prompts'
 
 import { collectSpecialFileContents, addFileOrDirectoryToContext } from '../../utils/prompt_utils'
-import { getConfig, getClovingConfig, getAllFiles } from '../../utils/config_utils'
+import { getConfig, getNearestClovingConfig, getAllFiles } from '../../utils/config_utils'
 import type { ClovingGPTOptions } from '../../utils/types'
 
 const generateContextPrompt = (files: string[], contextFiles: Record<string, string>): string => {
@@ -22,7 +22,7 @@ const generateContextPrompt = (files: string[], contextFiles: Record<string, str
 
   return `### Description of App
 
-${JSON.stringify(getClovingConfig(), null, 2)}
+${JSON.stringify(getNearestClovingConfig().config, null, 2)}
 
 ${specialFiles}
 

--- a/src/commands/tokens.ts
+++ b/src/commands/tokens.ts
@@ -6,7 +6,7 @@
 
 import fs from 'fs'
 import path from 'path'
-import { getClovingConfig } from '../utils/config_utils'
+import { getNearestClovingConfig } from '../utils/config_utils'
 import { getAllFilesInDirectory } from '../utils/prompt_utils'
 import type { ClovingGPTOptions } from '../utils/types'
 
@@ -67,7 +67,7 @@ const tokens = async (options: ClovingGPTOptions): Promise<void> => {
   prompt += `
 ### Description of App
 
-${JSON.stringify(getClovingConfig(), null, 2)}
+${JSON.stringify(getNearestClovingConfig().config, null, 2)}
 
 ${contextFileContents}`
 

--- a/src/managers/ProxyManager.ts
+++ b/src/managers/ProxyManager.ts
@@ -5,7 +5,7 @@ import path from 'path'
 
 import ClovingGPT from '../cloving_gpt'
 import ChunkManager from './ChunkManager'
-import { getClovingConfig } from '../utils/config_utils'
+import { getNearestClovingConfig } from '../utils/config_utils'
 import { getAllFilesInDirectory } from '../utils/prompt_utils'
 import type { ClovingGPTOptions } from '../utils/types'
 
@@ -113,7 +113,7 @@ ${content}
 
 ### Description of App
 
-${JSON.stringify(getClovingConfig(), null, 2)}
+${JSON.stringify(getNearestClovingConfig().config, null, 2)}
 
 ${contextFileContents}
 

--- a/src/managers/StreamManager.ts
+++ b/src/managers/StreamManager.ts
@@ -10,7 +10,7 @@ import ChunkManager from './ChunkManager'
 import BlockManager from './BlockManager'
 
 import { getPackageVersion } from '../utils/prompt_utils'
-import { getClovingConfig } from '../utils/config_utils'
+import { getNearestClovingConfig } from '../utils/config_utils'
 import { addFileOrDirectoryToContext, generateCodegenPrompt } from '../utils/prompt_utils'
 import type { CurrentNewBlock, ChatMessage } from '../utils/types'
 
@@ -274,7 +274,7 @@ class StreamManager extends EventEmitter {
    */
   protected async loadContextFiles(): Promise<void> {
     try {
-      const config = getClovingConfig()
+      const config = getNearestClovingConfig().config
       const primaryLanguage = config.languages.find((lang) => lang.primary)
       const defaultDirectory = primaryLanguage ? primaryLanguage.directory : '.'
       const testingDirectories =

--- a/src/utils/prompt_utils.ts
+++ b/src/utils/prompt_utils.ts
@@ -10,7 +10,7 @@ import { isBinaryFile } from 'isbinaryfile'
 import colors from 'colors'
 import { join } from 'path'
 
-import { getClovingConfig } from './config_utils'
+import { getNearestClovingConfig } from './config_utils'
 import {
   REVIEW_INSTRUCTIONS,
   DOCS_INSTRUCTIONS,
@@ -20,7 +20,7 @@ import {
   CODEGEN_EXAMPLES,
 } from './prompts'
 
-import type { ChatMessage, ClovingGPTOptions } from './types'
+import type { ClovingGPTOptions } from './types'
 
 /**
  * Retrieves the package version from package.json.
@@ -69,7 +69,7 @@ export const generateCodegenPrompt = (contextFilesContent: Record<string, string
 ## Description of App
 
 \`\`\`json
-${JSON.stringify(getClovingConfig(), null, 2)}
+${JSON.stringify(getNearestClovingConfig().config, null, 2)}
 \`\`\`
 
 ## Special Files
@@ -118,7 +118,7 @@ ${CODEGEN_EXAMPLES}
 ## Description of App
 
 \`\`\`json
-${JSON.stringify(getClovingConfig(), null, 2)}
+${JSON.stringify(getNearestClovingConfig().config, null, 2)}
 \`\`\`
 
 ## Special Files
@@ -160,7 +160,7 @@ export const generateReviewPrompt = (
 
     prompt += `### Description of App
 
-${JSON.stringify(getClovingConfig(), null, 2)}
+${JSON.stringify(getNearestClovingConfig().config, null, 2)}
 
 ${contextFileContents}
 

--- a/tests/utils/prompt_utils.test.ts
+++ b/tests/utils/prompt_utils.test.ts
@@ -3,6 +3,7 @@ import { CODEGEN_INSTRUCTIONS } from '../../src/utils/prompts'
 
 jest.mock('../../src/utils/config_utils', () => ({
   getClovingConfig: jest.fn().mockReturnValue({}),
+  getNearestClovingConfig: jest.fn().mockReturnValue({ config: {}, path: '' }),
 }))
 
 describe('prompt_utils', () => {


### PR DESCRIPTION
- Replace getClovingConfig with getNearestClovingConfig across multiple files
- Implement getClovingConfigAtPath for reading config from a specific path
- Update tests to mock getNearestClovingConfig