### PR TITLE
Add auto-accept option for commit messages

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cloving",
-  "version": "0.3.19",
+  "version": "0.3.20",
   "packageManager": "yarn@1.22.22",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -90,6 +90,7 @@ program
     '-m, --model <model>',
     'Select the model to use (e.g., openai, claude, ollama, ollama:llama3, claude:claude-3-5-sonnet-20240620)',
   )
+  .option('-a, --autoAccept', 'Automatically accept the generated commit message without editing')
   .action(commit)
 
 // Generate commands
@@ -143,6 +144,7 @@ generate
     '-m, --model <model>',
     'Select the model to use (e.g., openai, claude, ollama, ollama:llama3, claude:claude-3-5-sonnet-20240620)',
   )
+  .option('-a, --autoAccept', 'Automatically accept the generated commit message without editing')
   .action(commit)
 
 generate

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -45,6 +45,7 @@ export interface ClovingGPTOptions {
   port?: number
   stream?: boolean
   timeout?: number
+  autoAccept?: boolean
 }
 
 export interface ClovingModelConfig {


### PR DESCRIPTION
## Changes Overview

The main changes in this update focus on enhancing the commit process and adding an auto-accept feature for commit messages. Key modifications include:

1. Adding an auto-accept option to the CLI commands
2. Implementing auto-accept functionality in the CommitManager
3. Refactoring the commit process to accommodate the new auto-accept feature
4. Updating the ClovingGPTOptions interface to include the auto-accept option

## Reason for Changes

These changes aim to streamline the commit process for users who prefer an automated workflow. The auto-accept feature allows users to bypass manual editing of commit messages, potentially saving time in scenarios where quick commits are desired.

## Detailed Description

1. **CLI Command Updates**: Both the main program and the generate subcommand now include a new `-a, --autoAccept` option. This allows users to specify auto-accept behavior directly from the command line.

2. **CommitManager Enhancements**: 
   - A new `autoAccept` property is added to the CommitManager class.
   - The commit process is now split into two paths: one for auto-accept and one for manual editing.
   - When auto-accept is enabled, the commit is made directly without opening an editor.

3. **Commit Process Refactoring**: The existing commit process is preserved for cases where auto-accept is not enabled, maintaining backward compatibility.

4. **Type Definition Update**: The `ClovingGPTOptions` interface in `types.ts` is updated to include the `autoAccept` option, ensuring type safety throughout the application.